### PR TITLE
Fix ball generation subsurf modifier

### DIFF
--- a/pbr/scene/ball.py
+++ b/pbr/scene/ball.py
@@ -75,7 +75,7 @@ class Ball(BlenderObject):
         # Create subdiv surface modifiers if we have a new UV sphere
         if ball_info["mesh_path"] is None:
             bpy.ops.object.modifier_add(type="SUBSURF")
-            ball.modifiers["Subsurf"].name = "Ball_Subsurf"
+            ball.modifiers["Subdivision"].name = "Ball_Subsurf"
             ball_subsurf = ball.modifiers["Ball_Subsurf"]
             ball_subsurf.levels = blend_cfg.ball["subsurf_mod"]["levels"]
             ball_subsurf.render_levels = blend_cfg.ball["subsurf_mod"]["rend_levels"]


### PR DESCRIPTION
Simple bug fix that prevents an occasional crash that would happen when running nupbr.

 Has been known for a while but hasn't made it onto the main branch for whatever reason.
 
 It was on the robocup branch. https://github.com/NUbots/NUpbr/commit/9f081c5c86b60f3c6b4fbe840defe86376a86274