### PR TITLE
Fix invalid rotation matrices

### DIFF
--- a/pbr/config/scene_config.py
+++ b/pbr/config/scene_config.py
@@ -1,10 +1,11 @@
 # Field-specific Configuration Settings
 #   * All measurements are in SI units
 
-from math import pi, radians
+from math import pi
 from os import path, pardir
 import random
 import colorsys
+import numpy as np
 
 # Get project path
 proj_path = path.abspath(
@@ -19,6 +20,21 @@ num_shapes = 8
 
 # Number of robots to fill the scene
 num_robots = 3
+
+# The radius that defines the personal space of a robot
+robot_radius = 0.7
+
+# Field dimensions
+field_dims = {
+    "length": 9,
+    "width": 6,
+    "goal_area": {"length": 1, "width": 5},
+    "penalty_mark_dist": 2.1,
+    "centre_circle_radius": 0.75,
+    "border_width": 0.7,
+    "field_line_width": 0.05,
+    "grass_height": random.uniform(0.02, 0.05),
+}
 
 resources = {
     "robot": {
@@ -191,6 +207,7 @@ def configure_scene():
             ]
         }
     )
+
     # Add robot information
     cfg.update(
         {

--- a/pbr/pbr.py
+++ b/pbr/pbr.py
@@ -105,10 +105,14 @@ def main():
 
         cam_l.update(config["camera"])
 
-
         if out_cfg.output_imperfections:
             composition_nodes = bpy.context.scene.node_tree.nodes
-            env.randomise_imperfections(composition_nodes["Blur"], composition_nodes["RGB Curves"], composition_nodes["Mix"], composition_nodes["Exposure"])
+            env.randomise_imperfections(
+                composition_nodes["Blur"],
+                composition_nodes["RGB Curves"],
+                composition_nodes["Mix"],
+                composition_nodes["Exposure"],
+            )
 
         # Update shapes
         for ii in range(len(shapes)):
@@ -145,7 +149,7 @@ def main():
         points_on_field = util.point_on_field(
             camera_loc, hdr_data["mask_path"], env_info, len(robots) + 1
         )
-        print(points_on_field)
+        print("Points on field: \n", points_on_field)
         # Generate new world points for the robots and use this to update their location
         world_points = util.generate_moves(scene_config.field_dims)
         for ii in range(robot_start, len(robots)):
@@ -275,7 +279,6 @@ def main():
 
         bpy.context.view_layer.update()
 
-
         ##############################################
         ##                RENDERING                 ##
         ##############################################
@@ -338,7 +341,7 @@ def main():
                 )
 
         # Check that the rotation matrix of the main camera is valid
-        print(cam_l.obj.matrix_world)
+        print(f"Rotation matrix of {cam_l.obj.name}: \n", cam_l.obj.matrix_world)
 
         # Generate meta file
         with open(

--- a/pbr/pbr.py
+++ b/pbr/pbr.py
@@ -105,7 +105,7 @@ def main():
 
         cam_l.update(config["camera"])
 
-        
+
         if out_cfg.output_imperfections:
             composition_nodes = bpy.context.scene.node_tree.nodes
             env.randomise_imperfections(composition_nodes["Blur"], composition_nodes["RGB Curves"], composition_nodes["Mix"], composition_nodes["Exposure"])
@@ -271,7 +271,10 @@ def main():
 
         bpy.context.scene.frame_set(frame_num)
 
+        cam_l.set_tracking_target(tracking_target)
+
         bpy.context.view_layer.update()
+
 
         ##############################################
         ##                RENDERING                 ##

--- a/pbr/pbr.py
+++ b/pbr/pbr.py
@@ -10,10 +10,8 @@ import json
 # Add our current position to path to include package
 sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
 
-# Make sure the python dependencies for this script are installed
-import ensure_dependencies
 
-from math import pi, sqrt, ceil
+from math import pi
 
 from config import output_config as out_cfg
 from config import scene_config
@@ -90,7 +88,6 @@ def main():
 
     # Mount cameras to eye sockets
     cam_l.set_robot(robots[0].obj)
-    cam_r.set_robot(robots[0].obj)
 
     # Create camera anchor target for random field images
     anch = CameraAnchor()
@@ -107,7 +104,6 @@ def main():
         config = scene_config.configure_scene()
 
         cam_l.update(config["camera"])
-        cam_l.obj.keyframe_insert(data_path="location", frame=frame_num)
 
         # Update shapes
         for ii in range(len(shapes)):
@@ -241,8 +237,8 @@ def main():
             valid_tracks.append(anch)
 
         tracking_target = random.choice(valid_tracks).obj
-        # cam_l.set_tracking_target(tracking_target)
         robots[0].update_main_robot(tracking_target)
+
         cam_l.update(
             config["camera"],
             targets={
@@ -253,7 +249,6 @@ def main():
                 "target": tracking_target,
             },
         )
-        # robots[0].set_tracking_target(tracking_target)
 
         print(
             '[INFO] Frame {0}: ball: "{1}", map: "{2}", target: {3}'.format(
@@ -266,9 +261,11 @@ def main():
 
         # Update the camera then insert the rotation keyframe after rotating the camera
         # Updates scene to rectify rotation and location matrices and set the frame number for the current scene
-        cam_l.rotate((0, 0, pi / 2))
+        cam_l.obj.keyframe_insert(data_path="location", frame=frame_num)
         cam_l.obj.keyframe_insert(data_path="rotation_euler", frame=frame_num)
+
         bpy.context.scene.frame_set(frame_num)
+
         bpy.context.view_layer.update()
 
         ##############################################
@@ -331,6 +328,9 @@ def main():
                     os.path.join(out_cfg.depth_dir, filename) + ".exr0001",
                     os.path.join(out_cfg.depth_dir, filename) + ".exr",
                 )
+
+        # Check that the rotation matrix of the main camera is valid
+        print(cam_l.obj.matrix_world)
 
         # Generate meta file
         with open(

--- a/pbr/pbr.py
+++ b/pbr/pbr.py
@@ -144,7 +144,9 @@ def main():
         points_on_field = util.point_on_field(
             camera_loc, hdr_data["mask_path"], env_info, len(robots) + 1
         )
-
+        print(points_on_field)
+        # Generate new world points for the robots and use this to update their location
+        world_points = util.generate_moves(scene_config.field_dims)
         for ii in range(robot_start, len(robots)):
             # If we are autoplacing update the configuration
             if (
@@ -152,11 +154,12 @@ def main():
                 and is_semi_synthetic
                 and len(points_on_field) > 0
             ):
+
                 # Generate new ground point based on camera (actually robot parent of camera)
                 config["robot"][ii]["position"] = (
-                    points_on_field[ii][0],
-                    points_on_field[ii][1],
-                    env_info["position"]["z"] - 0.33
+                    world_points[ii - 1][0],
+                    world_points[ii - 1][1],
+                    world_points[ii - 1][2]
                     if ii == 0
                     else config["robot"][ii]["position"][2],
                 )

--- a/pbr/scene/camera.py
+++ b/pbr/scene/camera.py
@@ -19,23 +19,15 @@ class Camera(BlenderObject):
     def set_tracking_target(self, target):
         bpy.context.view_layer.objects.active = self.obj
 
-        if "Damped Track" not in self.obj.constraints:
-            bpy.ops.object.constraint_add(type="DAMPED_TRACK")
+        # tracks the ball position while keeping camera upright
+        if "Track To" not in self.obj.constraints:
+            bpy.ops.object.constraint_add(type="TRACK_TO")
 
-        # allow ball to be slightly off centre in camera view
-        constr = self.obj.constraints["Damped Track"]
+        constr = self.obj.constraints["Track To"]
         constr.target = target
         constr.track_axis = "TRACK_NEGATIVE_Z"
+        constr.up_axis = "UP_Y"
         constr.influence = 0.9
-
-        if "Limit Rotation" not in self.obj.constraints:
-            bpy.ops.object.constraint_add(type="LIMIT_ROTATION")
-
-        # sets the camera so it does not tilt
-        rot_constr = self.obj.constraints["Limit Rotation"]
-        rot_constr.use_limit_y = True
-        rot_constr.min_y = 0
-        rot_constr.max_y = 0
 
     # Add parent camera for stereo vision
     def set_stereo_pair(self, cam):

--- a/pbr/scene/camera.py
+++ b/pbr/scene/camera.py
@@ -30,10 +30,6 @@ class Camera(BlenderObject):
         tracking_target = bpy.data.objects["Tracking_Target"]
         tracking_target.location = target.location
 
-        if (not self.ball_in_front(target)):
-            print("found one!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-            self.move_tracking_target(tracking_target)
-
         bpy.context.view_layer.objects.active = self.obj
         # tracks the empty's position while keeping camera upright
         if "Track To" not in self.obj.constraints:
@@ -44,6 +40,9 @@ class Camera(BlenderObject):
         constr.track_axis = "TRACK_NEGATIVE_Z"
         constr.up_axis = "UP_Y"
         constr.influence = 0.9
+
+        if (not self.ball_in_front(target)):
+            self.move_tracking_target(tracking_target)
 
     # Add parent camera for stereo vision
     def set_stereo_pair(self, cam):
@@ -70,7 +69,6 @@ class Camera(BlenderObject):
         child_constr.use_location_y = False
         child_constr.use_location_z = False
 
-    # There is some behaviour that is not working correctly with the child of constraint, I have to investigate further
     def set_robot(self, robot):
         # Ensure object is selected to receive added constraints
         bpy.context.view_layer.objects.active = self.obj
@@ -97,25 +95,18 @@ class Camera(BlenderObject):
                 cam.lens_unit = "FOV"
                 cam.angle = cam_config["fov"]
 
-        if targets is not None:
-            # self.obj.rotation_euler = [np.pi / 2, 0, np.pi / 2]
-            self.set_tracking_target(target=targets["target"])
-
     def ball_in_front(self, target):
-        # Using head of robot to avoid strange camera vectors
         robot = bpy.context.scene.objects["r0_Head"]
-
         forward = util.find_forward_vector(robot)
-
         object_vector = target.location - (robot.location + (forward * 0.4))
         object_vector.z = 0  # Set the Z component of the object vector to 0 to consider only X and Y components
-        object_vector.normalize()  # Normalize the object vector after setting Z to 0
+        object_vector.normalize()
 
         angle = math.degrees(forward.angle(object_vector))
 
         return (angle < 90)
 
-    # Make sure the tracking target is in front of the robot
+    # Make sure the robot looks slightly ahead
     def move_tracking_target(self, target):
         # Using head of robot to avoid strange camera vectors
         robot = bpy.context.scene.objects["r0_Head"]

--- a/pbr/scene/camera.py
+++ b/pbr/scene/camera.py
@@ -58,11 +58,11 @@ class Camera(BlenderObject):
         bpy.context.view_layer.objects.active = self.obj
 
         bpy.ops.object.constraint_add(type="COPY_LOCATION")
-        child_constr = self.obj.constraints["Copy Location"]
-        child_constr.name = "robot_L_Eye_Loc"
+        loc_constr = self.obj.constraints["Copy Location"]
+        loc_constr.name = "robot_L_Eye_Loc"
 
         # Bind to robot's chosen eye position - must make sure that the main robot being used is the NUgus_esh
-        child_constr.target = bpy.data.objects[f"{robot.name[:2]}_L_Eye_Socket"]
+        loc_constr.target = bpy.data.objects[f"{robot.name[:2]}_L_Eye_Socket"]
         self.obj.rotation_euler = [np.pi / 2, 0, np.pi / 2]
 
     def update(self, cam_config, targets=None):

--- a/pbr/scene/camera.py
+++ b/pbr/scene/camera.py
@@ -28,13 +28,14 @@ class Camera(BlenderObject):
         constr.track_axis = "TRACK_NEGATIVE_Z"
         constr.influence = 0.9
 
-        # sets the camera so it does not tilt
         if "Limit Rotation" not in self.obj.constraints:
             bpy.ops.object.constraint_add(type="LIMIT_ROTATION")
-            rot_constr = self.obj.constraints["Limit Rotation"]
-            rot_constr.use_limit_y = True
-            rot_constr.min_y = 0
-            rot_constr.max_y = 0
+
+        # sets the camera so it does not tilt
+        rot_constr = self.obj.constraints["Limit Rotation"]
+        rot_constr.use_limit_y = True
+        rot_constr.min_y = 0
+        rot_constr.max_y = 0
 
     # Add parent camera for stereo vision
     def set_stereo_pair(self, cam):

--- a/pbr/scene/camera.py
+++ b/pbr/scene/camera.py
@@ -52,22 +52,18 @@ class Camera(BlenderObject):
         child_constr.use_location_y = False
         child_constr.use_location_z = False
 
-    def set_robot(self, robot, left_eye=True):
+    # There is some behaviour that is not working correctly with the child of constraint, I have to investigate further
+    def set_robot(self, robot):
         # Ensure object is selected to receive added constraints
         bpy.context.view_layer.objects.active = self.obj
 
-        bpy.ops.object.constraint_add(type="CHILD_OF")
-        child_constr = self.obj.constraints["Child Of"]
-        child_constr.name = "robot_child"
+        bpy.ops.object.constraint_add(type="COPY_LOCATION")
+        child_constr = self.obj.constraints["Copy Location"]
+        child_constr.name = "robot_L_Eye_Loc"
 
         # Bind to robot's chosen eye position - must make sure that the main robot being used is the NUgus_esh
-        if left_eye:
-            child_constr.target = bpy.data.objects[f"{robot.name[:2]}_L_Eye_Socket"]
-        else:
-            child_constr.target = bpy.data.objects[f"{robot.name[:2]}_R_Eye_Socket"]
-
-        # Invert child of
-        child_constr.inverse_matrix = robot.matrix_world.inverted()
+        child_constr.target = bpy.data.objects[f"{robot.name[:2]}_L_Eye_Socket"]
+        self.obj.rotation_euler = [np.pi / 2, 0, np.pi / 2]
 
     def update(self, cam_config, targets=None):
         # Fix for blender being stupid
@@ -84,10 +80,5 @@ class Camera(BlenderObject):
                 cam.angle = cam_config["fov"]
 
         if targets is not None:
-            # Generate camera object following the right hand rule orientation (Front of camera points towards +x, +z is up)
-            self.obj.location = [0, 0, 0]
-            self.obj.rotation_euler = [np.pi / 2, 0, -np.pi / 2]
-            left_eye_loc = targets["robot"]["left_eye"].location
-
-            self.obj.location = left_eye_loc
+            self.obj.rotation_euler = [np.pi / 2, 0, np.pi / 2]
             self.set_tracking_target(target=targets["target"])

--- a/pbr/scene/camera.py
+++ b/pbr/scene/camera.py
@@ -22,10 +22,19 @@ class Camera(BlenderObject):
         if "Damped Track" not in self.obj.constraints:
             bpy.ops.object.constraint_add(type="DAMPED_TRACK")
 
+        # allow ball to be slightly off centre in camera view
         constr = self.obj.constraints["Damped Track"]
         constr.target = target
         constr.track_axis = "TRACK_NEGATIVE_Z"
-        constr.influence = 0.75
+        constr.influence = 0.9
+
+        # sets the camera so it does not tilt
+        if "Limit Rotation" not in self.obj.constraints:
+            bpy.ops.object.constraint_add(type="LIMIT_ROTATION")
+            rot_constr = self.obj.constraints["Limit Rotation"]
+            rot_constr.use_limit_y = True
+            rot_constr.min_y = 0
+            rot_constr.max_y = 0
 
     # Add parent camera for stereo vision
     def set_stereo_pair(self, cam):

--- a/pbr/scene/camera.py
+++ b/pbr/scene/camera.py
@@ -23,14 +23,15 @@ class Camera(BlenderObject):
     # Sets target for camera to track
     def set_tracking_target(self, target):
         # create a tracking target at the location of the ball
-        bpy.ops.object.add(type='EMPTY', location=(0, 0, 0))
-        tracking_target = bpy.context.active_object
-        tracking_target.name = "Tracking_Target"
-        ball_location = bpy.data.objects["Ball"].location
-        tracking_target.location = ball_location
+        if ("Tracking_Target" not in bpy.data.objects):
+            bpy.ops.object.add(type='EMPTY', location=(0, 0, 0))
+            bpy.context.active_object.name='Tracking_Target'
+
+        tracking_target = bpy.data.objects["Tracking_Target"]
+        tracking_target.location = bpy.data.objects["Ball"].location
 
         if (not self.ball_in_front(target)):
-            print("found one!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+             print("found one!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
             self.move_tracking_target(tracking_target)
 
         bpy.context.view_layer.objects.active = self.obj

--- a/pbr/scene/camera.py
+++ b/pbr/scene/camera.py
@@ -31,7 +31,7 @@ class Camera(BlenderObject):
         tracking_target.location = bpy.data.objects["Ball"].location
 
         if (not self.ball_in_front(target)):
-             print("found one!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+            print("found one!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
             self.move_tracking_target(tracking_target)
 
         bpy.context.view_layer.objects.active = self.obj

--- a/pbr/scene/camera.py
+++ b/pbr/scene/camera.py
@@ -28,7 +28,7 @@ class Camera(BlenderObject):
             bpy.context.active_object.name='Tracking_Target'
 
         tracking_target = bpy.data.objects["Tracking_Target"]
-        tracking_target.location = bpy.data.objects["Ball"].location
+        tracking_target.location = target.location
 
         if (not self.ball_in_front(target)):
             print("found one!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
@@ -98,7 +98,7 @@ class Camera(BlenderObject):
                 cam.angle = cam_config["fov"]
 
         if targets is not None:
-            self.obj.rotation_euler = [np.pi / 2, 0, np.pi / 2]
+            # self.obj.rotation_euler = [np.pi / 2, 0, np.pi / 2]
             self.set_tracking_target(target=targets["target"])
 
     def ball_in_front(self, target):

--- a/pbr/util.py
+++ b/pbr/util.py
@@ -286,9 +286,65 @@ def point_on_field(cam_location, mask_path, env_info, num_points):
 
     # Check if environment map has field points, else set to origin
     if len(field_coords) > 0:
-        for ii in range(num_points):
+        while len(ground_points) < scene_config.num_robots:
             # Get random field point
             y, x = field_coords[rand.randint(0, field_coords.shape[0] - 1)]
+            yproj, xproj = project_to_ground(y, x, cam_location, img, env_info)
+
+            if any(
+                [
+                    (p[0] - xproj) ** 2 + (p[1] - yproj) ** 2
+                    < scene_config.robot_radius**2
+                    for p in ground_points
+                ]
+            ):
+                continue
 
             ground_points.append(project_to_ground(y, x, cam_location, img, env_info))
+
     return ground_points
+
+
+def generate_moves(field_meta, z_coord=0.3):
+    """
+    Generates world coordinates for all of the robots in world space
+    Arguments:
+        field_meta (dict): The field meta data - this is where the field dimensions are derived from
+        z_coord (float): The z coordinate of the base hip (if the robot mesh is NUgus_esh, and torso if it is just NUgus) from z=0.0
+    Returns:
+        world_points (list): A list of world coordinates for each robot
+
+    Note: This function also relies from a config value in scene_config.py called robot_radius.
+          This radius defines the area around a robot that is considered to be occupied.
+          It can also be interpreted as the minimum distance between any two robots.
+          This is to make sure that no two robots can look like they have spawned on top of one another.
+    """
+    field_dims = (
+        field_meta["length"] + 2 * field_meta["border_width"],
+        field_meta["width"] + 2 * field_meta["border_width"],
+    )
+
+    # Use the field dimensions to generate a set of moves for the robots
+    abs_x, abs_y = field_dims
+
+    world_points = []
+
+    while len(world_points) < scene_config.num_robots:
+        # Get random field point
+        point = np.random.uniform(
+            low=(-abs_x / 2, -abs_y / 2), high=(abs_x / 2, abs_y / 2)
+        )
+        # If any of the points are within the radius of a robot, skip this point
+        if any(
+            [
+                (p[0] - point[0]) ** 2 + (p[1] - point[1]) ** 2
+                < scene_config.robot_radius**2
+                for p in world_points
+            ]
+        ):
+            continue
+
+        # Add the point to the list if the current iteration is not skipped
+        world_points.append((*point, z_coord))
+
+    return world_points

--- a/pbr/util.py
+++ b/pbr/util.py
@@ -8,6 +8,7 @@ import cv2
 
 from config import scene_config
 from scene import environment as env
+from mathutils import Vector
 
 # Import assets from path as defined by asset_list
 # Where asset list ('assets') is a list of two-tuples, each containing
@@ -348,3 +349,14 @@ def generate_moves(field_meta, z_coord=0.3):
         world_points.append((*point, z_coord))
 
     return world_points
+
+# Find the forward vector of an object that you pass in
+def find_forward_vector(obj):
+    local_matrix = obj.matrix_local
+    global_matrix = obj.matrix_world @ local_matrix
+    rotation_matrix = global_matrix.to_3x3()
+    forward = rotation_matrix @ Vector((1, 0, 0))
+    forward.z = 0  # Set the Z component of the forward vector to 0 to make it parallel to the ground
+    forward.normalize()  # Normalize the forward vector after setting Z to 0
+
+    return forward


### PR DESCRIPTION
Parenting the camera to the left eye resulted to the camera's transform being an inverse of the left eye's transform which resulted to an incorrect rotation matrix for the camera. This fix constrains the camera's location onto the left eye instead of parenting it. This way, the camera gets to keep its rotation transform with respect to world. The script outputs the main camera's world matrix after each iteration for checking.

Some commented code and unused imports were also removed as I read through the code.